### PR TITLE
LDAP w/ Omnibus, user_filter, server URL, Workhorse & Unicorn addresses

### DIFF
--- a/gitlab/files/config/gitlab.yml
+++ b/gitlab/files/config/gitlab.yml
@@ -123,6 +123,9 @@ production: &base
     bind_dn: {{ identity.get("bind_dn") }}
     password: {{ identity.get("password") }}
     allow_username_or_email_login: {{ identity.get("allow_username_or_email_login", "true")|replace("True","true")|replace("False", "false") }}
+    {% if identity.user_filter is defined %}
+    user_filter: '{{ identity.get("user_filter") }}'
+    {% endif %}
   {% else %}
   ldap:
     enabled: false

--- a/gitlab/files/gitlab.rb
+++ b/gitlab/files/gitlab.rb
@@ -475,7 +475,7 @@ gitlab_workhorse['enable'] = true
 gitlab_workhorse['listen_network'] = "tcp"
 # gitlab_workhorse['listen_network'] = "unix"
 # gitlab_workhorse['listen_umask'] = 000
-gitlab_workhorse['listen_addr'] = "127.0.0.1:8181"
+gitlab_workhorse['listen_addr'] = "{{ server.workhorse_host }}:{{ server.workhorse_port }}"
 # gitlab_workhorse['listen_addr'] = "/var/opt/gitlab/gitlab-workhorse/socket"
 # gitlab_workhorse['auth_backend'] = "http://localhost:8080"
 
@@ -541,8 +541,8 @@ gitlab_workhorse['listen_addr'] = "127.0.0.1:8181"
 # unicorn['worker_processes'] = 2
 
 ### Advanced settings
-# unicorn['listen'] = '127.0.0.1'
-# unicorn['port'] = 8080
+unicorn['listen'] = '{{ server.unicorn_host }}'
+unicorn['port'] = {{ server.unicorn_port }}
 # unicorn['socket'] = '/var/opt/gitlab/gitlab-rails/sockets/gitlab.socket'
 # unicorn['pidfile'] = '/opt/gitlab/var/unicorn/unicorn.pid'
 # unicorn['tcp_nopush'] = true

--- a/gitlab/files/gitlab.rb
+++ b/gitlab/files/gitlab.rb
@@ -508,11 +508,7 @@ gitlab_workhorse['listen_network'] = "tcp"
 # gitlab_workhorse['listen_network'] = "unix"
 # gitlab_workhorse['listen_umask'] = 000
 
-{% if server.workhorse.bind is defined -%}
-gitlab_workhorse['listen_addr'] = "{{ server.workhorse.bind.get('host', '127.0.0.1') }}:{{ server.workhorse.bind.get('port', '8181') }}"
-{%- else %}
-gitlab_workhorse['listen_addr'] = "127.0.0.0.8181"
-{%- endif %}
+gitlab_workhorse['listen_addr'] = "{{ server.workhorse.bind.host }}:{{ server.workhorse.bind.port }}"
 
 # gitlab_workhorse['listen_addr'] = "/var/opt/gitlab/gitlab-workhorse/socket"
 # gitlab_workhorse['auth_backend'] = "http://localhost:8080"
@@ -580,10 +576,8 @@ gitlab_workhorse['listen_addr'] = "127.0.0.0.8181"
 
 ### Advanced settings
 
-{% if server.unicorn.bind is defined -%}
-unicorn['listen'] = "{{ server.unicorn.bind.get('host', '127.0.0.1') }}"
-unicorn['port'] = {{ server.unicorn.bind.get('port', '8080') }}
-{%- endif %}
+unicorn['listen'] = "{{ server.unicorn.bind.host }}"
+unicorn['port'] = {{ server.unicorn.bind.port }}
 # unicorn['socket'] = '/var/opt/gitlab/gitlab-rails/sockets/gitlab.socket'
 # unicorn['pidfile'] = '/opt/gitlab/var/unicorn/unicorn.pid'
 # unicorn['tcp_nopush'] = true

--- a/gitlab/files/gitlab.rb
+++ b/gitlab/files/gitlab.rb
@@ -510,8 +510,10 @@ gitlab_workhorse['listen_network'] = "tcp"
 
 {% if server.workhorse.bind is defined -%}
 gitlab_workhorse['listen_addr'] = "{{ server.workhorse.bind.get('host', '127.0.0.1') }}:{{ server.workhorse.bind.get('port', '8181') }}"
+{%- else %}
+gitlab_workhorse['listen_addr'] = "127.0.0.0.8181"
 {%- endif %}
-"
+
 # gitlab_workhorse['listen_addr'] = "/var/opt/gitlab/gitlab-workhorse/socket"
 # gitlab_workhorse['auth_backend'] = "http://localhost:8080"
 

--- a/gitlab/map.jinja
+++ b/gitlab/map.jinja
@@ -15,7 +15,20 @@
         'shell_version': shell_version,
         'repository': {},
         'pkgs': ['gitlab-ce'],
-        'source_pkgs': ["build-essential", "zlib1g-dev", "libyaml-dev", "libssl-dev", "libgdbm-dev", "libreadline-dev", "libncurses5-dev", "libffi-dev", "checkinstall", "libxml2-dev", "libxslt1-dev",  "libmysqlclient-dev", "libpq-dev", "libcurl4-openssl-dev", "libicu-dev", "curl", "python-docutils", "cmake"]
+        'source_pkgs': ["build-essential", "zlib1g-dev", "libyaml-dev", "libssl-dev", "libgdbm-dev", "libreadline-dev", "libncurses5-dev", "libffi-dev", "checkinstall", "libxml2-dev", "libxslt1-dev",  "libmysqlclient-dev", "libpq-dev", "libcurl4-openssl-dev", "libicu-dev", "curl", "python-docutils", "cmake"],
+        'workhorse': {
+          'bind': {
+            'host': '127.0.0.1',
+            'port': 8181
+          }
+        },
+        'unicorn': {
+          'bind': {
+            'host': '127.0.0.1',
+            'port': 8080
+          }
+        }
+
     },
 }, merge=salt['pillar.get']('gitlab:server')) %}
 


### PR DESCRIPTION
This PR adds a few configuration options:
- user_filter can be used to filter users in LDAP authentication
- LDAP can now be used in Omnibus installations
- Changed `server_name` to `url`, which allows you to use http:// instead of https://
- Trusted proxies can be specified in pillars
- Workhorse & Unicorn listen addresses can be configured, which is needed for proxied installations