### PR TITLE
Add missing mail.port to SMTP config

### DIFF
--- a/gitlab/files/gitlab.rb
+++ b/gitlab/files/gitlab.rb
@@ -386,7 +386,7 @@ gitlab_rails['redis_port'] = 6379
 
 gitlab_rails['smtp_enable'] = true
 gitlab_rails['smtp_address'] = "{{ server.mail.host }}"
-gitlab_rails['smtp_port'] = 465
+gitlab_rails['smtp_port'] = {{ server.mail.port }}
 gitlab_rails['smtp_user_name'] = "{{ server.mail.user }}"
 gitlab_rails['smtp_password'] = "{{ server.mail.password }}"
 gitlab_rails['smtp_domain'] = "{{ server.mail.get('domain', '') }}"


### PR DESCRIPTION
mail.port was being ignored, the hard coded port 465 was being used. This PR makes use of mail.port.