### PR TITLE
Improve SMTP configuration

### DIFF
--- a/gitlab/files/gitlab.rb
+++ b/gitlab/files/gitlab.rb
@@ -384,15 +384,23 @@ gitlab_rails['redis_port'] = 6379
 ###! Docs: https://docs.gitlab.com/omnibus/settings/smtp.html
 ###! **Use smtp instead of sendmail/postfix.**
 
-gitlab_rails['smtp_enable'] = true
+gitlab_rails['smtp_enable'] = {{ server.mail.get('enabled', 'false') }}
+
+{% if server.mail.get('enabled', 'false')|lower == 'true' %}
 gitlab_rails['smtp_address'] = "{{ server.mail.host }}"
 gitlab_rails['smtp_port'] = {{ server.mail.port }}
 gitlab_rails['smtp_user_name'] = "{{ server.mail.user }}"
 gitlab_rails['smtp_password'] = "{{ server.mail.password }}"
 gitlab_rails['smtp_domain'] = "{{ server.mail.get('domain', '') }}"
+{% if server.mail.get('authentication', False) %}
 gitlab_rails['smtp_authentication'] = "login"
-# gitlab_rails['smtp_enable_starttls_auto'] = true
-gitlab_rails['smtp_tls'] = {{ server.mail.use_tls|lower }}
+gitlab_rails['smtp_user_name'] = "{{ server.mail.get('user', '') }}"
+gitlab_rails['smtp_password'] = "{{ server.mail.get('password', '') }}"
+{% endif %}
+
+gitlab_rails['smtp_enable_starttls_auto'] = {{ server.mail.get('use_starttls', 'false') }}
+gitlab_rails['smtp_tls'] = {{ server.mail.get('use_tls', 'false')|lower }}
+{% endif %}
 
 ###! **Can be: 'none', 'peer', 'client_once', 'fail_if_no_peer_cert'**
 ###! Docs: http://api.rubyonrails.org/classes/ActionMailer/Base.html

--- a/gitlab/files/gitlab.rb
+++ b/gitlab/files/gitlab.rb
@@ -387,10 +387,8 @@ gitlab_rails['redis_port'] = 6379
 gitlab_rails['smtp_enable'] = {{ server.mail.get('enabled', 'false') }}
 
 {% if server.mail.get('enabled', 'false')|lower == 'true' %}
-gitlab_rails['smtp_address'] = "{{ server.mail.host }}"
+gitlab_rails['smtp_address'] = "{{ server.mail.get('host', '127.0.0.1') }}"
 gitlab_rails['smtp_port'] = {{ server.mail.port }}
-gitlab_rails['smtp_user_name'] = "{{ server.mail.user }}"
-gitlab_rails['smtp_password'] = "{{ server.mail.password }}"
 gitlab_rails['smtp_domain'] = "{{ server.mail.get('domain', '') }}"
 {% if server.mail.get('authentication', False) %}
 gitlab_rails['smtp_authentication'] = "login"

--- a/gitlab/files/gitlab.rb
+++ b/gitlab/files/gitlab.rb
@@ -388,7 +388,7 @@ gitlab_rails['smtp_enable'] = {{ server.mail.get('enabled', 'false') }}
 
 {% if server.mail.get('enabled', 'false')|lower == 'true' -%}
 gitlab_rails['smtp_address'] = "{{ server.mail.get('host', '127.0.0.1') }}"
-gitlab_rails['smtp_port'] = {{ server.mail.port }}
+gitlab_rails['smtp_port'] = {{ server.mail.get('port', 25) }}
 gitlab_rails['smtp_domain'] = "{{ server.mail.get('domain', '') }}"
 {% if server.mail.get('authentication', False) -%}
 gitlab_rails['smtp_authentication'] = "login"

--- a/gitlab/files/gitlab.rb
+++ b/gitlab/files/gitlab.rb
@@ -386,19 +386,19 @@ gitlab_rails['redis_port'] = 6379
 
 gitlab_rails['smtp_enable'] = {{ server.mail.get('enabled', 'false') }}
 
-{% if server.mail.get('enabled', 'false')|lower == 'true' %}
+{% if server.mail.get('enabled', 'false')|lower == 'true' -%}
 gitlab_rails['smtp_address'] = "{{ server.mail.get('host', '127.0.0.1') }}"
 gitlab_rails['smtp_port'] = {{ server.mail.port }}
 gitlab_rails['smtp_domain'] = "{{ server.mail.get('domain', '') }}"
-{% if server.mail.get('authentication', False) %}
+{% if server.mail.get('authentication', False) -%}
 gitlab_rails['smtp_authentication'] = "login"
 gitlab_rails['smtp_user_name'] = "{{ server.mail.get('user', '') }}"
 gitlab_rails['smtp_password'] = "{{ server.mail.get('password', '') }}"
-{% endif %}
+{%- endif -%}
 
 gitlab_rails['smtp_enable_starttls_auto'] = {{ server.mail.get('use_starttls', 'false') }}
 gitlab_rails['smtp_tls'] = {{ server.mail.get('use_tls', 'false')|lower }}
-{% endif %}
+{%- endif %}
 
 ###! **Can be: 'none', 'peer', 'client_once', 'fail_if_no_peer_cert'**
 ###! Docs: http://api.rubyonrails.org/classes/ActionMailer/Base.html


### PR DESCRIPTION
This improves the configuration of SMTP options slightly.
- Omit everything if smtp is disabled
- If authentication is disabled, you don't need to supply username & password
- Add default values for most options